### PR TITLE
feat: reverting contribution guide as it was wrongly pushed by bot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,79 +1,32 @@
-# Contributing to AsyncAPI
-We love your input! We want to make contributing to this project as easy and transparent as possible.
+# Contributing
 
-## Contribution recogniton
+Contributions are **welcome** and will be fully **credited**.
 
-We use [All Contributors](https://allcontributors.org/docs/en/specification) specification to handle recognitions. For more details read [this](https://github.com/asyncapi/community/blob/master/recognize-contributors.md) document.
+We accept contributions via Pull Requests on [Github](https://github.com/asyncapi/php-template).
 
-## Summary of the contribution flow
-
-The following is a summary of the ideal contribution flow. Please, note that Pull Requests can also be rejected by the maintainers when appropriate.
-
-```
-    ┌───────────────────────┐
-    │                       │
-    │    Open an issue      │
-    │  (a bug report or a   │
-    │   feature request)    │
-    │                       │
-    └───────────────────────┘
-               ⇩
-    ┌───────────────────────┐
-    │                       │
-    │  Open a Pull Request  │
-    │   (only after issue   │
-    │     is approved)      │
-    │                       │
-    └───────────────────────┘
-               ⇩
-    ┌───────────────────────┐
-    │                       │
-    │   Your changes will   │
-    │     be merged and     │
-    │ published on the next │
-    │        release        │
-    │                       │
-    └───────────────────────┘
-```
-
-## Code of Conduct
-AsyncAPI has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](./CODE_OF_CONDUCT.md) so that you can understand what sort of behaviour is expected.
-
-## Our Development Process
-We use Github to host code, to track issues and feature requests, as well as accept pull requests.
-
-## Issues
-[Open an issue](https://github.com/asyncapi/asyncapi/issues/new) **only** if you want to report a bug or a feature. Don't open issues for questions or support, instead join our [Slack workspace](https://www.asyncapi.com/slack-invite) and ask there. Don't forget to follow our [Slack Etiquette](https://github.com/asyncapi/community/blob/master/slack-etiquette.md) while interacting with community members! It's more likely you'll get help, and much faster!
-
-## Bug Reports and Feature Requests
-
-Please use our issues templates that provide you with hints on what information we need from you to help you out.
 
 ## Pull Requests
 
-**Please, make sure you open an issue before starting with a Pull Request, unless it's a typo or a really obvious error.** Pull requests are the best way to propose changes to the specification. Get familiar with our document that explains [Git workflow](https://github.com/asyncapi/community/blob/master/git-workflow.md) used in our repositories.
+- **[PSR-12 Coding Standard](https://www.php-fig.org/psr/psr-12/)** - Check the code style with ``$ composer check-style`` and fix it with ``$ composer fix-style``.
 
-## Conventional commits
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 
-Our repositories follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification. Releasing to GitHub and NPM is done with the support of [semantic-release](https://semantic-release.gitbook.io/semantic-release/).
+- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
 
-Pull requests should have a title that follows the specification, otherwise, merging is blocked. If you are not familiar with the specification simply ask maintainers to modify. You can also use this cheatsheet if you want:
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
 
-- `fix: ` prefix in the title indicates that PR is a bug fix and PATCH release must be triggered.
-- `feat: ` prefix in the title indicates that PR is a feature and MINOR release must be triggered.
-- `docs: ` prefix in the title indicates that PR is only related to the documentation and there is no need to trigger release.
-- `chore: ` prefix in the title indicates that PR is only related to cleanup in the project and there is no need to trigger release.
-- `test: ` prefix in the title indicates that PR is only related to tests and there is no need to trigger release.
-- `refactor: ` prefix in the title indicates that PR is only related to refactoring and there is no need to trigger release.
+- **Create feature branches** - Don't ask us to pull from your master branch.
 
-What about MAJOR release? just add `!` to the prefix, like `fix!: ` or `refactor!: `
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
 
-Prefix that follows specification is not enough though. Remember that the title must be clear and descriptive with usage of [imperative mood](https://chris.beams.io/posts/git-commit/#imperative).
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
 
-Happy contributing :heart:
 
-## License
-When you submit changes, your submissions are understood to be under the same [Apache 2.0 License](https://github.com/asyncapi/asyncapi/blob/master/LICENSE) that covers the project. Feel free to [contact the maintainers](https://www.asyncapi.com/slack-invite) if that's a concern.
+## Running Tests
 
-## References
-This document was adapted from the open-source contribution guidelines for [Facebook's Draft](https://github.com/facebook/draft-js/blob/master/CONTRIBUTING.md).
+``` bash
+$ composer test
+```
+
+
+**Happy coding**!


### PR DESCRIPTION
…ll also help to fire the build process for the first public release

<!--- Provide a general summary of your changes in the Title above -->

## Description

It reverts back the contribution guide as it was recently introduced and updated.

## Motivation and context

The change was a mistake when implementing the build process. We're reverting to the version we actually want and we're also marking as a feat so the release process is fired

## How has this been tested?

No need for tests, it's only an MD

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
